### PR TITLE
Update SoccerNet-Echoes information

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Currently, we have published the following datasets:
 * Soccer Summarization, Soccer game captions and summary in English for game summarization. [ [publication](https://dl.acm.org/doi/10.1145/3552463.3557019) ]
 * SoccerMon, Subjective and objective data collected over two years from two different elite women´s soccer teams.
 * SoccerSum, The SoccerSum Dataset for Automated Detection, Segmentation, and Tracking of Objects on the Soccer Pitch [ [publication](http://localhost:3000/---) ]
+* SoccerNet-Echoes, SoccerNet-Echoes: A Soccer Game Audio Commentary Dataset [ [publication](https://arxiv.org/abs/2405.07354) ]
 * PMData , A lifelogging dataset of 16 persons during 5 months using Fitbit, Google Forms and PMSys.
 * TACDEC, TACDEC: Dataset of Tackle Events in Soccer Game Videos [ [publication](https://dl.acm.org/doi/10.1145/3625468.3652166) ]
 

--- a/datasets/soccernet-echoes.md
+++ b/datasets/soccernet-echoes.md
@@ -13,7 +13,7 @@ tags:
 
 ## Accessing the Dataset
 
-The dataset is available on: https://github.com/SoccerNet/sn-echoes.
+The dataset is available [here](https://github.com/SoccerNet/sn-echoes).
 
 ## Terms of Use
 
@@ -39,7 +39,7 @@ The dataset is fully open for research and educational purposes. Use of the data
 ## Contact
 
 For any questions regarding the dataset, or to discuss potential collaboration and joint research opportunities, please contact the following people:
-- Sushant Gautam: [sushant@simula.no] (mailto:sushant@simula.no)
+- Sushant Gautam: [sushant@simula.no](mailto:sushant@simula.no)
 - Mehdi Houshmand: [mehdihou@oslomet.no](mailto:mehdihou@oslomet.no)
 - Cise Midoglu: [cise@simula.no](mailto:cise@simula.no)
 - Pål Halvorsen: [paalh@simula.no](mailto:paalh@simula.no)

--- a/datasets/soccernet-echoes.md
+++ b/datasets/soccernet-echoes.md
@@ -3,7 +3,7 @@ title: 'SoccerNet-Echoes'
 desc: 'A Soccer Game Audio Commentary Dataset'
 thumbnail: /thumbnails/soccernet-echoes.png
 github: https://github.com/SoccerNet/sn-echoes
-publication: ---
+publication: https://arxiv.org/abs/2405.07354
 hidden: false
 tags:
   - text


### PR DESCRIPTION
I have updated the information for the SoccerNet-Echoes dataset. The readme file now includes a link to the publication and the dataset is available on GitHub. Additionally, I have fixed a typo in the contact email address.