### PR TITLE
Clear dataset-site placeholders from GitHub metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,51 +4,56 @@ A collection of open datasets published by Simula Research Laboratory and Simula
 Currently, we have published the following datasets: 
 
 **Medical and Biology Datasets**
-* Depresjon, The Depresjon Dataset. [ [publication](https://dl.acm.org/doi/10.1145/3204949.3208125) ]
-* HyperKvasir, The Largest Gastrointestinal Dataset. [ [publication](https://www.nature.com/articles/s41597-020-00622-y) ]
-* HYPERAKTIV, A Motor Activity Database of Patients with ADHD. [ [publication](https://dl.acm.org/doi/10.1145/3458305.3478454) ]
-* KvasirCapsule SEG, A Capsule Endoscopy Segmentation Dataset. [ [publication](https://arxiv.org/pdf/2104.11138) ]
-* Cellular, A cell autophagy dataset. [ [publication](https://github.com/simula/cellular) ]
-* GastroVision, A multicenter dataset. [ [publication](https://arxiv.org/abs/2307.08140) ]
-* Nerthus, A Bowel Preparation Quality Video Dataset. [ [publication](https://dl.acm.org/do/10.1145/3193165/abs/) ]
-* Kvasir-VQA: A Text-Image Pair GI Tract Dataset
-* Kvasir Capsule, The largest gastrointestinal PillCAM dataset. [ [publication](https://www.nature.com/articles/s41597-021-00920-z) ]
-* Kvasir Instrument, A gastrointestinal instrument Dataset. [ [publication](https://link.springer.com/chapter/10.1007/978-3-030-67835-7_19) ]
-* Kvasir SEG, Segmented Polyp Dataset for Computer Aided Gastrointestinal Disease Detection. [ [publication](https://dl.acm.org/doi/10.1007/978-3-030-37734-2_37) ]
-* Kvasir, A Multi-Class Image-Dataset for Computer Aided Gastrointestinal Disease Detection. [ [publication](https://dl.acm.org/do/10.1145/3193289/abs/) ]
-* Psykose, A Motor Activity Database of Patients with Schizophrenia. [ [publication](https://ieeexplore.ieee.org/document/9182896) ]
-* VISEM QC, A sperm quality control dataset.
-* VISEM, A Multimodal Video Dataset of Human Spermatozoa. [ [publication](https://dl.acm.org/doi/10.1145/3304109.3325814) ]
+* Cellular, A cell autophagy dataset. [[project](https://github.com/simula/cellular)]
+* Depresjon, The Depresjon Dataset. [[publication](https://dl.acm.org/doi/10.1145/3204949.3208125) | [project](https://datasets.simula.no/depresjon/)]
+* GastroVision, A multicenter dataset. [[publication](https://arxiv.org/abs/2307.08140) | [project](https://github.com/DebeshJha/GastroVision)]
+* HTAD, A Home-Tasks Activities Dataset with Wrist-accelerometer and Audio Features. [[publication](https://link.springer.com/chapter/10.1007/978-3-030-67835-7_17) | [project](https://osf.io/4dnh8/)]
+* HYPERAKTIV, A Motor Activity Database of Patients with ADHD. [[publication](https://dl.acm.org/doi/10.1145/3458305.3478454) | [project](https://github.com/simula/hyperaktiv)]
+* HyperKvasir, The Largest Gastrointestinal Dataset. [[publication](https://www.nature.com/articles/s41597-020-00622-y) | [project](https://github.com/simula/hyper-kvasir)]
+* Kvasir, A Multi-Class Image-Dataset for Computer Aided Gastrointestinal Disease Detection. [[publication](https://doi.org/10.1145/3083187.3083212) | [project](https://datasets.simula.no/kvasir/)]
+* Kvasir Capsule, The largest gastrointestinal PillCAM dataset. [[publication](https://www.nature.com/articles/s41597-021-00920-z) | [project](https://github.com/simula/kvasir-capsule)]
+* Kvasir Instrument, A gastrointestinal instrument Dataset. [[publication](https://doi.org/10.1007/978-3-030-67835-7_19) | [project](https://osf.io/kp6my/)]
+* Kvasir SEG, Segmented Polyp Dataset for Computer Aided Gastrointestinal Disease Detection. [[publication](https://dl.acm.org/doi/10.1007/978-3-030-37734-2_37) | [project](https://datasets.simula.no/kvasir-seg/)]
+* Kvasir-VQA, A Text-Image Pair GI Tract Dataset. [[publication](https://doi.org/10.1145/3689096.3689458) | [project](https://huggingface.co/datasets/SimulaMet-HOST/Kvasir-VQA)]
+* Kvasir-VQA-x1, A Large-Scale Multi-Task Benchmark for GI Tract Visual Question Answering. [[publication](https://doi.org/10.1007/978-3-032-08009-7_6) | [project](https://github.com/simula/Kvasir-VQA-x1)]
+* KvasirCapsule SEG, A Capsule Endoscopy Segmentation Dataset. [[publication](https://arxiv.org/abs/2104.11138) | [project](https://github.com/DebeshJha/NanoNet)]
+* MedMultiPoints, A Multimodal Dataset for Object Detection, Localization, and Counting in Medical Imaging. [[publication](https://arxiv.org/abs/2505.16647) | [project](https://github.com/Simula/PointDetectCount)]
+* Medico Multimedia - VISEM Tracking, A sperm tracking dataset. [[publication](https://doi.org/10.1145/3304109.3325814) | [project](https://multimediaeval.github.io/editions/2022/)]
+* Nerthus, A Bowel Preparation Quality Video Dataset. [[publication](https://doi.org/10.1145/3083187.3083216) | [project](https://datasets.simula.no/nerthus/)]
+* Psykose, A Motor Activity Database of Patients with Schizophrenia. [[publication](https://ieeexplore.ieee.org/document/9182896) | [project](https://osf.io/dgjzu/)]
+* VISEM, A Multimodal Video Dataset of Human Spermatozoa. [[publication](https://dl.acm.org/doi/10.1145/3304109.3325814) | [project](https://datasets.simula.no/visem/)]
+* VISEM QC, A sperm quality control dataset. [[project](https://datasets.simula.no/visem-qc/)]
 
-**Sport Datasets**
-* Alfheim, Soccer video and player position dataset. [ [publication](https://dl.acm.org/doi/10.1145/2557642.2563677) ]
-* ARX, A Text-Classification Dataset Consisting of Norwegian Soccer Articles from VG and TV2. [ [publication](https://ieeexplore.ieee.org/abstract/document/8877417/) ]
-* ExposureEngine, Oriented Logo Detection & Sponsor Visibility Analytics (Dataset).
-* Heimdallr, A Dataset For Sport Analysis.
-* HockeyAI, A Multi-Class Ice Hockey Dataset for Object Detection. [ [publication](https://dl.acm.org/doi/10.1145/3712676.3718335) ]
-* HockeyRink: A Dataset for Precise Ice Hockey Rink Keypoint Mapping and Analytics. [ [publication](https://dl.acm.org/doi/10.1145/3712676.3718338) ]
-* HockeyOrient, A Dataset for Ice Hockey Player Orientation Classification. [ [publication](https://dl.acm.org/doi/10.1145/3712676.3718342) ]
-* ScopeSense, A 8.5-month sport, nutrition, and lifestyle lifelogging dataset.
-* Soccer Summarization, Soccer game captions and summary in English for game summarization. [ [publication](https://dl.acm.org/doi/10.1145/3552463.3557019) ]
-* SoccerMon, Subjective and objective data collected over two years from two different elite women´s soccer teams.
-* SoccerSum, The SoccerSum Dataset for Automated Detection, Segmentation, and Tracking of Objects on the Soccer Pitch [ [publication](http://localhost:3000/---) ]
-* SoccerNet-Echoes, SoccerNet-Echoes: A Soccer Game Audio Commentary Dataset [ [publication](https://arxiv.org/abs/2405.07354) ]
-* PMData , A lifelogging dataset of 16 persons during 5 months using Fitbit, Google Forms and PMSys.
-* TACDEC, TACDEC: Dataset of Tackle Events in Soccer Game Videos [ [publication](https://dl.acm.org/doi/10.1145/3625468.3652166) ]
+**Sport and Activity Datasets**
+* Alfheim, Soccer video and player position dataset. [[publication](https://dl.acm.org/doi/10.1145/2557642.2563677) | [project](https://datasets.simula.no/alfheim/)]
+* Arx, A Text-Classification Dataset Consisting of Norwegian Soccer Articles from VG and TV2. [[publication](https://ieeexplore.ieee.org/abstract/document/8877417/) | [project](https://datasets.simula.no/arx/)]
+* ExposureEngine, Oriented Logo Detection and Sponsor Visibility Analytics in Sports Broadcasts. [[project](https://huggingface.co/datasets/SimulaMet-HOST/ExposureEngine)]
+* Heimdallr, A Dataset For Sport Analysis. [[project](https://datasets.simula.no/heimdallr/)]
+* HockeyAI, A Multi-Class Ice Hockey Dataset for Object Detection. [[publication](https://dl.acm.org/doi/10.1145/3712676.3718335) | [project](https://github.com/acmmmsys/2025-HockeyAI)]
+* HockeyOrient, A Dataset for Ice Hockey Player Orientation Classification. [[publication](https://dl.acm.org/doi/10.1145/3712676.3718342) | [project](https://github.com/acmmmsys/2025-HockeyOrient)]
+* HockeyRink, A Dataset for Precise Ice Hockey Rink Keypoint Mapping and Analytics. [[publication](https://dl.acm.org/doi/10.1145/3712676.3718338) | [project](https://github.com/acmmmsys/2025-HockeyRink)]
+* PMData, A lifelogging dataset of 16 persons during 5 months using Fitbit, Google Forms and PMSys. [[publication](https://dl.acm.org/doi/10.1145/3339825.3394926) | [project](https://osf.io/vx4bk/)]
+* ScopeSense, A 8.5-month sport, nutrition, and lifestyle lifelogging dataset. [[project](https://osf.io/v5acr/)]
+* Soccer Summarization, Soccer game captions and summary in English for game summarization. [[publication](https://dl.acm.org/doi/10.1145/3552463.3557019) | [project](https://github.com/simula/soccer-summarization)]
+* SoccerChat, A Multimodal Video-Text Dataset for Natural Language Soccer Game Understanding. [[publication](https://arxiv.org/abs/2505.16630) | [project](https://github.com/simula/SoccerChat)]
+* SoccerMon, Subjective and objective data collected over two years from two different elite women´s soccer teams. [[project](https://osf.io/uryz9/)]
+* SoccerNet-Echoes, A Soccer Game Audio Commentary Dataset. [[publication](https://arxiv.org/abs/2405.07354) | [project](https://github.com/SoccerNet/sn-echoes)]
+* SoccerSum, The SoccerSum Dataset for Automated Detection, Segmentation, and Tracking of Objects on the Soccer Pitch. [[publication](https://doi.org/10.1145/3625468.3652180) | [project](https://github.com/simula/SoccerSum)]
+* TACDEC, TACDEC: Dataset of Tackle Events in Soccer Game Videos. [[publication](https://doi.org/10.1145/3625468.3652166) | [project](https://github.com/simula/tacdec)]
 
 **Other Datasets**
-* Anarchy Online, Server-side Network Traffic from Anarchy Online: Analysis, Statistics and Applications. [ [publication](https://datasets.simula.no/ao/mmsys2012-dataset.pdf) ]
-* European Cloud Cover, A dataset containing reanalysis data from ERA5 and satellite retrievals from METeosat Second Generation. [ [publication](https://www.mdpi.com/2504-2289/5/4/62/pdf) ]
-* Eye Tracker, A Serious Game Based Dataset. [ [publication](http://ceur-ws.org/Vol-1345/gamifir15_5.pdf) ]
-* HSDPA, HSDPA-bandwidth logs for mobile HTTP streaming scenarios.
-* HTAD, A Home-Tasks Activities Dataset with Wrist-accelerometer and Audio Features. [ [publication](https://link.springer.com/chapter/10.1007/978-3-030-67835-7_17) ]
-* Image Sentiment, A dataset for image sentiment analysis. [ [publication](https://arxiv.org/pdf/2009.03051.pdf) ]
-* Njord, A fishing boat dataset.
-* Right Inflight, A Dataset for Exploring the Automatic Prediction of Movies Suitable for a Watching Situation.
-* THREAT, A Large Annotated Corpus for Detection of Violent Threats.
-* Toadstool, A Dataset for Training Emotional and Intelligent Machines Playing Super Mario Bros. [ [publication](https://dl.acm.org/doi/10.1145/3339825.3394939) ]
-* WICO Graph Dataset, A Labeled Dataset of Twitter Subgraphs based on Conspiracy Theory and 5G-Corona Misinformation Tweets. [ [publication](https://dl.acm.org/doi/10.1145/3472720.3483617) ]
-* WICO Text, A labeled dataset of conspiracy theory and 5G-corona misinformation tweets. [ [publication](https://dl.acm.org/doi/abs/10.1145/3472720.3483617) ]
+* Anarchy Online, Server-side Network Traffic from Anarchy Online: Analysis, Statistics and Applications. [[publication](https://datasets.simula.no/ao/mmsys2012-dataset.pdf) | [project](https://datasets.simula.no/ao/)]
+* European Cloud Cover, A dataset containing reanalysis data from ERA5 and satellite retrievals from METeosat Second Generation. [[publication](https://www.mdpi.com/2504-2289/5/4/62/pdf) | [project](https://osf.io/kqdgx/)]
+* Eye Tracker, A Serious Game Based Dataset. [[publication](http://ceur-ws.org/Vol-1345/gamifir15_5.pdf) | [project](https://datasets.simula.no/eye-tracker/)]
+* HSDPA, HSDPA-bandwidth logs for mobile HTTP streaming scenarios. [[publication](http://home.ifi.uio.no/paalh/publications/files/mmsys2013-dataset.pdf) | [project](https://datasets.simula.no/hsdpa/)]
+* Image Sentiment, A dataset for image sentiment analysis. [[publication](https://arxiv.org/pdf/2009.03051.pdf) | [project](https://osf.io/xakp2/)]
+* Njord, A fishing boat dataset. [[project](https://github.com/simula/njord)]
+* Right Inflight, A Dataset for Exploring the Automatic Prediction of Movies Suitable for a Watching Situation. [[project](https://zenodo.org/record/1118338)]
+* THREAT, A Large Annotated Corpus for Detection of Violent Threats. [[project](https://datasets.simula.no/threat/)]
+* Toadstool, A Dataset for Training Emotional and Intelligent Machines Playing Super Mario Bros. [[publication](https://dl.acm.org/doi/10.1145/3339825.3394939) | [project](https://github.com/simula/toadstool)]
+* WICO Graph Dataset, A Labeled Dataset of Twitter Subgraphs based on Conspiracy Theory and 5G-Corona Misinformation Tweets. [[publication](https://dl.acm.org/doi/10.1145/3472720.3483617) | [project](https://osf.io/5m3by/)]
+* WICO Text, A labeled dataset of conspiracy theory and 5G-corona misinformation tweets. [[publication](https://doi.org/10.1145/3472720.3483617) | [project](https://datasets.simula.no/wico-text/)]
+
 
 ## How to contribute
 To add a new **dataset**, follow these steps:

--- a/datasets/alfheim.md
+++ b/datasets/alfheim.md
@@ -3,6 +3,7 @@ title: 'Alfheim'
 desc: 'Soccer video and player position dataset.'
 thumbnail: /thumbnails/alfheim.png
 publication: https://dl.acm.org/doi/10.1145/2557642.2563677
+github: ''
 tags:
   - soccer
   - video analysis

--- a/datasets/ao.md
+++ b/datasets/ao.md
@@ -3,6 +3,7 @@ title: 'Anarchy Online'
 desc: 'Server-side Network Traffic from Anarchy Online: Analysis, Statistics and Applications.'
 thumbnail: /thumbnails/anarchy-online.png
 publication: https://datasets.simula.no/ao/mmsys2012-dataset.pdf
+github: ''
 tags:
   - climate change
   - sensor

--- a/datasets/arx.md
+++ b/datasets/arx.md
@@ -3,6 +3,7 @@ title: 'Arx'
 desc: 'A Text-Classification Dataset Consisting of Norwegian Soccer Articles from VG and TV2.'
 thumbnail: /thumbnails/arx.jpg
 publication: https://ieeexplore.ieee.org/abstract/document/8877417/
+github: ''
 tags:
   - soccer
   - text

--- a/datasets/cellular.md
+++ b/datasets/cellular.md
@@ -2,6 +2,7 @@
 title: 'Cellular'
 desc: 'A cell autophagy dataset.'
 thumbnail: /thumbnails/cellular.png
+publication: ''
 github: https://github.com/simula/cellular
 hidden: false
 tags:

--- a/datasets/depresjon.md
+++ b/datasets/depresjon.md
@@ -3,6 +3,7 @@ title: 'Depresjon'
 desc: 'The Depresjon Dataset.'
 thumbnail: /thumbnails/depresjon.png
 publication: https://dl.acm.org/doi/10.1145/3204949.3208125
+github: ''
 tags:
   - mental health
   - sensor

--- a/datasets/ecc-dataset.md
+++ b/datasets/ecc-dataset.md
@@ -3,6 +3,7 @@ title: 'European Cloud Cover'
 desc: 'A dataset containing reanalysis data from ERA5 and satellite retrievals from METeosat Second Generation.'
 thumbnail: /thumbnails/european-cloud-cover.jpg
 publication: https://www.mdpi.com/2504-2289/5/4/62/pdf
+github: https://osf.io/kqdgx/
 tags:
   - climate change
   - sensor

--- a/datasets/exposure-engine.md
+++ b/datasets/exposure-engine.md
@@ -2,8 +2,8 @@
 title: 'ExposureEngine'
 desc: 'Oriented Logo Detection and Sponsor Visibility Analytics in Sports Broadcasts'
 thumbnail: /thumbnails/exposure-engine.jpg
-publication: ---
-github: ---
+publication: ''
+github: https://huggingface.co/datasets/SimulaMet-HOST/ExposureEngine
 hidden: false
 tags:
   - Logo Detection

--- a/datasets/eye-tracker.md
+++ b/datasets/eye-tracker.md
@@ -3,6 +3,7 @@ title: 'Eye Tracker'
 desc: 'A Serious Game Based Dataset.'
 thumbnail: /thumbnails/eye-tracker.png
 publication: http://ceur-ws.org/Vol-1345/gamifir15_5.pdf
+github: ''
 tags:
   - climate change
   - sensor

--- a/datasets/gastrovision.md
+++ b/datasets/gastrovision.md
@@ -2,6 +2,7 @@
 title: 'GastroVision'
 desc: 'A multicenter dataset.'
 thumbnail: /thumbnails/gastrovision.jpg
+publication: https://arxiv.org/abs/2307.08140
 github: https://github.com/DebeshJha/GastroVision
 hidden: false
 tags:

--- a/datasets/heimdallr.md
+++ b/datasets/heimdallr.md
@@ -2,6 +2,8 @@
 title: 'Heimdallr'
 desc: 'A Dataset For Sport Analysis.'
 thumbnail: /thumbnails/heimdallr.png
+publication: ''
+github: ''
 tags:
   - soccer
   - video analysis

--- a/datasets/hsdpa.md
+++ b/datasets/hsdpa.md
@@ -2,6 +2,8 @@
 title: 'HSDPA'
 desc: 'HSDPA-bandwidth logs for mobile HTTP streaming scenarios.'
 thumbnail: /thumbnails/hsdpa-bandwidth-traces.jpg
+publication: http://home.ifi.uio.no/paalh/publications/files/mmsys2013-dataset.pdf
+github: ''
 tags:
   - networks
   - streaming 

--- a/datasets/htad.md
+++ b/datasets/htad.md
@@ -3,6 +3,7 @@ title: 'HTAD'
 desc: 'A Home-Tasks Activities Dataset with Wrist-accelerometer and Audio Features.'
 thumbnail: /thumbnails/htad.png
 publication: https://link.springer.com/chapter/10.1007/978-3-030-67835-7_17
+github: https://osf.io/4dnh8/
 tags:
   - activity
   - sensor

--- a/datasets/image-sentiment.md
+++ b/datasets/image-sentiment.md
@@ -3,6 +3,7 @@ title: 'Image Sentiment'
 desc: 'A dataset for image sentiment analysis.'
 thumbnail: /thumbnails/sentiment.jpg
 publication: https://arxiv.org/pdf/2009.03051.pdf
+github: https://osf.io/xakp2/
 tags:
   - sentiment analysis
   - images

--- a/datasets/kvasir-capsule-seg.md
+++ b/datasets/kvasir-capsule-seg.md
@@ -2,7 +2,7 @@
 title: 'KvasirCapsule SEG'
 desc: 'A Capsule Endoscopy Segmentation Dataset.'
 thumbnail: /thumbnails/kvasir-capsule-seg.jpg
-publication: https://arxiv.org/abs/2104.11138#:~:text=NanoNet%3A%20Real%2DTime%20Polyp%20Segmentation%20in%20Video%20Capsule%20Endoscopy%20and%20Colonoscopy,-Debesh%20Jha%2C%20Nikhil&text=Deep%20learning%20in%20gastrointestinal%20endoscopy,to%20assess%20lesions%20more%20accurately.
+publication: https://arxiv.org/abs/2104.11138
 github: https://github.com/DebeshJha/NanoNet
 tags:
   - gastrointestinal

--- a/datasets/kvasir-instrument.md
+++ b/datasets/kvasir-instrument.md
@@ -2,7 +2,8 @@
 title: 'Kvasir Instrument'
 desc: 'A gastrointestinal instrument Dataset.'
 thumbnail: /thumbnails/kvasir-instrument.jpg
-publication: https://link.springer.com/chapter/10.1007/978-3-030-67835-7_19
+publication: https://doi.org/10.1007/978-3-030-67835-7_19
+github: https://osf.io/kp6my/
 tags:
   - gastrointestinal
   - sgementation

--- a/datasets/kvasir-instrument.md
+++ b/datasets/kvasir-instrument.md
@@ -6,7 +6,7 @@ publication: https://doi.org/10.1007/978-3-030-67835-7_19
 github: https://osf.io/kp6my/
 tags:
   - gastrointestinal
-  - sgementation
+  - segmentation
 ---
 
 Gastrointestinal (GI) tract pathologies are screened, biopsied, and resected (if needed) periodically using surgical tools. However, these biopsied and/or resected areas are not tracked due to which the video analysis for assessing disease burden or the amount of pathology resection remains unknown. To tackle such issues, we have released the novel “Kvasir-Instrument: Diagnostic and therapeutic tool segmentation dataset in gastrointestinal endoscopy” dataset, which consists of 590 annotated frames comprising of GI procedure tools such as snares, balloons, biopsy forceps, etc. By adding segmentation masks and bounding boxes information to this dataset, we enable computer vision and GI endoscopy researchers to contribute to the field of automated tool segmentation.

--- a/datasets/kvasir-seg.md
+++ b/datasets/kvasir-seg.md
@@ -3,6 +3,7 @@ title: 'Kvasir SEG'
 desc: 'Segmented Polyp Dataset for Computer Aided Gastrointestinal Disease Detection.'
 thumbnail: /thumbnails/kvasir-seg.png
 publication: https://dl.acm.org/doi/10.1007/978-3-030-37734-2_37
+github: ''
 tags:
   - gastrointestinal
   - segmentation

--- a/datasets/kvasir-vqa.md
+++ b/datasets/kvasir-vqa.md
@@ -2,7 +2,8 @@
 title: 'Kvasir-VQA'
 desc: 'A Text-Image Pair GI Tract Dataset'
 thumbnail: /thumbnails/kvasir.jpg # change
-publication: 
+publication: https://doi.org/10.1145/3689096.3689458
+github: https://huggingface.co/datasets/SimulaMet-HOST/Kvasir-VQA
 tags:
   - gastrointestinal
   - images

--- a/datasets/kvasir.md
+++ b/datasets/kvasir.md
@@ -2,7 +2,8 @@
 title: 'Kvasir'
 desc: 'A Multi-Class Image-Dataset for Computer Aided Gastrointestinal Disease Detection.'
 thumbnail: /thumbnails/kvasir.jpg
-publication: https://dl.acm.org/do/10.1145/3193289/abs/
+publication: https://doi.org/10.1145/3083187.3083212
+github: ''
 tags:
   - gastrointestinal
   - images

--- a/datasets/nerthus.md
+++ b/datasets/nerthus.md
@@ -2,7 +2,8 @@
 title: 'Nerthus'
 desc: 'A Bowel Preparation Quality Video Dataset.'
 thumbnail: /thumbnails/nerthus.jpg
-publication: https://dl.acm.org/do/10.1145/3193165/abs/
+publication: https://doi.org/10.1145/3083187.3083216
+github: ''
 tags:
   - gastrointestinal
   - images

--- a/datasets/njord.md
+++ b/datasets/njord.md
@@ -2,6 +2,7 @@
 title: 'Njord'
 desc: 'A fishing boat dataset.'
 thumbnail: /thumbnails/njord.jpeg
+publication: ''
 github: https://github.com/simula/njord
 hidden: false
 tags:

--- a/datasets/pmdata.md
+++ b/datasets/pmdata.md
@@ -3,6 +3,7 @@ title: 'PMData '
 desc: 'A lifelogging dataset of 16 persons during 5 months using Fitbit, Google Forms and PMSys.'
 thumbnail: /thumbnails/pmdata.jpg
 publication: https://dl.acm.org/doi/10.1145/3339825.3394926
+github: https://osf.io/vx4bk/
 tags:
   - sports
   - sensor

--- a/datasets/psykose.md
+++ b/datasets/psykose.md
@@ -3,6 +3,7 @@ title: 'Psykose'
 desc: 'A Motor Activity Database of Patients with Schizophrenia.'
 thumbnail: /thumbnails/psykose.png
 publication: https://ieeexplore.ieee.org/document/9182896
+github: https://osf.io/dgjzu/
 tags:
   - mental health
   - sensor

--- a/datasets/right-inflight.md
+++ b/datasets/right-inflight.md
@@ -2,6 +2,8 @@
 title: 'Right Inflight'
 desc: 'A Dataset for Exploring the Automatic Prediction of Movies Suitable for a Watching Situation.'
 thumbnail: /thumbnails/right-inflight.png
+publication: ''
+github: https://zenodo.org/record/1118338
 tags:
   - climate change
   - sensor

--- a/datasets/scopesense.md
+++ b/datasets/scopesense.md
@@ -2,6 +2,8 @@
 title: 'ScopeSense'
 desc: 'A 8.5-month sport, nutrition, and lifestyle lifelogging dataset.'
 thumbnail: /thumbnails/right-inflight.png
+publication: ''
+github: https://osf.io/v5acr/
 hidden: false
 tags:
   - lifelogging

--- a/datasets/soccermon.md
+++ b/datasets/soccermon.md
@@ -2,6 +2,8 @@
 title: 'SoccerMon'
 desc: 'Subjective and objective data collected over two years from two different elite women´s soccer teams.'
 thumbnail: /thumbnails/soccermon.png
+publication: ''
+github: https://osf.io/uryz9/
 hidden: false
 tags:
   - soccer

--- a/datasets/soccersum.md
+++ b/datasets/soccersum.md
@@ -2,8 +2,8 @@
 title: 'SoccerSum'
 desc: 'The SoccerSum Dataset for Automated Detection, Segmentation, and Tracking of Objects on the Soccer Pitch'
 thumbnail: /thumbnails/soccersum.jpeg
+publication: https://doi.org/10.1145/3625468.3652180
 github: https://github.com/simula/SoccerSum
-publication: ---
 hidden: false
 tags:
   - text

--- a/datasets/tacdec.md
+++ b/datasets/tacdec.md
@@ -2,8 +2,8 @@
 title: 'TACDEC'
 desc: 'TACDEC: Dataset of Tackle Events in Soccer Game Videos'
 thumbnail: '/thumbnails/arx.jpg'
-GitHub: https://github.com/simula/tacdec
-publication: ---
+publication: https://doi.org/10.1145/3625468.3652166
+github: https://github.com/simula/tacdec
 hidden: false
 tags:
   - football

--- a/datasets/threat.md
+++ b/datasets/threat.md
@@ -2,6 +2,8 @@
 title: 'THREAT'
 desc: 'A Large Annotated Corpus for Detection of Violent Threats.'
 thumbnail: /thumbnails/threat.png
+publication: ''
+github: ''
 tags:
   - violent threats
   - text

--- a/datasets/visem-qc.md
+++ b/datasets/visem-qc.md
@@ -2,6 +2,8 @@
 title: 'VISEM QC'
 desc: 'A sperm quality control dataset.'
 thumbnail: /thumbnails/visem.png
+publication: ''
+github: ''
 hidden: false
 tags:
   - sperm

--- a/datasets/visem-tracking.md
+++ b/datasets/visem-tracking.md
@@ -2,6 +2,8 @@
 title: 'Medico Multimedia - VISEM Tracking'
 desc: 'A sperm tracking dataset.'
 thumbnail: /thumbnails/visem-qc.png
+publication: https://doi.org/10.1145/3304109.3325814
+github: https://multimediaeval.github.io/editions/2022/
 hidden: true
 tags:
   - sperm

--- a/datasets/visem.md
+++ b/datasets/visem.md
@@ -3,6 +3,7 @@ title: 'VISEM'
 desc: 'A Multimodal Video Dataset of Human Spermatozoa.'
 thumbnail: /thumbnails/visem.png
 publication: https://dl.acm.org/doi/10.1145/3304109.3325814
+github: ''
 tags:
   - sperm
   - videos

--- a/datasets/wico-graph.md
+++ b/datasets/wico-graph.md
@@ -3,6 +3,7 @@ title: 'WICO Graph Dataset'
 desc: 'A Labeled Dataset of Twitter Subgraphs based on Conspiracy Theory and 5G-Corona Misinformation Tweets.'
 thumbnail: /thumbnails/wico.png
 publication: https://dl.acm.org/doi/10.1145/3472720.3483617
+github: https://osf.io/5m3by/
 tags:
   - misinformation
   - text

--- a/datasets/wico-text.md
+++ b/datasets/wico-text.md
@@ -2,7 +2,8 @@
 title: 'WICO Text'
 desc: 'A labeled dataset of conspiracy theory and 5G-corona misinformation tweets.'
 thumbnail: /thumbnails/wico.png
-publication: https://dl.acm.org/doi/abs/10.1145/3472720.3483617
+publication: https://doi.org/10.1145/3472720.3483617
+github: ''
 tags:
   - 5G
   - COVID


### PR DESCRIPTION
## Summary
- clear the GitHub front-matter fields that previously pointed back to datasets.simula.no across the affected dataset pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914dccfcab8832d9775b2f1ea8c7ab3)